### PR TITLE
Fix HLS list size argument in ffmpeg command

### DIFF
--- a/services/video_service.py
+++ b/services/video_service.py
@@ -20,11 +20,9 @@ def ffmpeg_hls(outdir, w, h, fps, pix_fmt, bitrate_kbps, frag_sec):
         "ffmpeg","-nostdin","-hide_banner","-loglevel","error",
         "-f","rawvideo","-pix_fmt",pix_fmt,"-s",f"{w}x{h}","-r",str(fps),"-i","-",
         "-an","-c:v","h264_v4l2m2m","-b:v",f"{bitrate_kbps}k","-g",str(int(fps*2)),
-        "-f","hls","-hls_time",str(frag_sec)," -hls_list_size","0","-hls_flags","independent_segments",
+        "-f","hls","-hls_time",str(frag_sec),"-hls_list_size","0","-hls_flags","independent_segments",
         plist
     ]
-    # fix: remove stray space in "-hls_list_size"
-    cmd[14] = "-hls_list_size"
     return subprocess.Popen(cmd, stdin=subprocess.PIPE)
 
 def watcher_enqueue(outdir, sid, stream, stop_evt):


### PR DESCRIPTION
## Summary
- fix spacing in ffmpeg HLS list size argument

## Testing
- `python -m py_compile services/video_service.py`
- `python - <<'PY'
import ast, json, pathlib
src = pathlib.Path('services/video_service.py').read_text()
module = ast.parse(src)
for node in module.body:
    if isinstance(node, ast.FunctionDef) and node.name == 'ffmpeg_hls':
        for n in node.body:
            if isinstance(n, ast.Assign) and any(isinstance(t, ast.Name) and t.id=='cmd' for t in n.targets):
                list_node = n.value
                consts = [elt.value for elt in list_node.elts if isinstance(elt, ast.Constant)]
                print(json.dumps(consts, indent=2))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b1f8ad9de0832da75c93bd05de2f51