### PR TITLE
Add control stream configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,8 +19,10 @@ queue:
   port: 6379
   stream_fragments: video:fragments
   stream_tasks: ml:tasks
+  stream_controls: video:controls
   group_fragments: g1
   group_tasks: g1
+  group_controls: g1
 
 paths:
   fragments_root: /dev/shm/frags


### PR DESCRIPTION
## Summary
- include `stream_controls` and `group_controls` in queue configuration
- confirm services reference the new control stream and group names

## Testing
- `python -m py_compile common/config.py services/tof_service.py services/video_service.py`
- `python - <<'PY'
from common.config import load_config
cfg = load_config('config.yaml')
print('stream_controls:', cfg.queue.stream_controls)
print('group_controls:', cfg.queue.group_controls)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f8b0e6fc832db2ceaeb9b2d89d84