### PR TITLE
Add I2C bus option to sensor config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 sensor:
+  i2c_bus: 1
   threshold_mm: 500
   arm_delay_ms: 500
   inactivity_timeout_ms: 6000


### PR DESCRIPTION
## Summary
- add `i2c_bus` selection to `sensor` configuration
- document ToF service's use of `CFG.sensor.i2c_bus` for `ExtendedI2C`

## Testing
- `python -m py_compile services/tof_service.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1f8b27ef8832d9fe997adfad75459